### PR TITLE
to resolve complie error and format syslog  warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ddserver
   SECTION:=utils
   CATEGORY:=Multimedia
-  DEPENDS:=+libusb-1.0 +uclibcxx
+  DEPENDS:=+libusb-1.0 +uclibcxx +libstdcpp
   TITLE:=Server for DSLR camera to use with DslrDashboard
   MAINTAINER:=Zoltan Hubai <hubaiz@gmail.com>
 endef
@@ -32,7 +32,7 @@ endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBS="-nodefaultlibs -lgcc -lc -lusb-1.0 -lpthread -luClibc++" \
+		LIBS="-lgcc -lc -lusb-1.0 -lpthread -luClibc++" \
 		LDFLAGS="$(EXTRA_LDFLAGS)" \
 		CXXFLAGS="$(TARGET_CFLAGS) $(EXTRA_CPPFLAGS)" \
 		$(TARGET_CONFIGURE_OPTS) \

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -94,7 +94,7 @@ void Communicator::sendWelcomeMessage()
 bool Communicator::readFromClient()
 {
 	bool result = false;
-	ssize_t r = 0;
+	uint32_t r = 0;
 	uint32_t packetSize = 0;
 
 	r = read(mSocket, &packetSize, 4);
@@ -111,12 +111,12 @@ bool Communicator::readFromClient()
 			result = processPacket(buf, packetSize - 4);
 		}
 		else
-			syslog(LOG_ERR, "Error reading packet : %ld", r);
+			syslog(LOG_ERR, "Error reading packet : %u", r);
 
 		free(buf);
 
 	} else
-		syslog(LOG_ERR, "Error reading total packet size: %ld", r);
+		syslog(LOG_ERR, "Error reading total packet size: %u", r);
 
 
 
@@ -659,7 +659,7 @@ void Communicator::sendUsbDeviceList(uint32_t sessionId)
 				imgUsbDevices.insert(imgUsbDevices.begin(), imgUsbDevice);
 			}
 		}
-		syslog(LOG_INFO, "Imaging USB devices found: %lu", imgUsbDevices.size());
+		syslog(LOG_INFO, "Imaging USB devices found: %u", imgUsbDevices.size());
 	}
 
 	libusb_free_device_list(devs, 1); //free the list, unref the devices in it


### PR DESCRIPTION
complie error for openwrt(master 20160921) to resolve these problems 
 I'm try to complie ddserver for openwrt(tl-mr12u) ,found these error

undefined reference to symbol '_Unwind_Resume@@GCC_3.0'
libgcc_s.so.1:error adding symbols: DSO missing from command line

## Resolve complie
1) change to "DslrDashboardServer" path
2) edit "Makefile" line 18
from
DEPENDS:=+libusb-1.0 +uclibcxx
change to
DEPENDS:=+libusb-1.0 +uclibcxx +libstdcpp

3)edit "Makefile" line 34
from
LIBS="-nodefaultlibs -lgcc -lc -lusb-1.0 -lpthread -luClibc++"
change to
LIBS="-lgcc -lc -lusb-1.0 -lpthread -luClibc++"

4)to reconfigury openwrt
make menuconfig

to save config

5) to recomplie ddserver to success

## the syslog warning
update  	"communicator.cpp"