### PR TITLE
Fix Linker For OpenWRT/Lede v17.01.5+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBS="-nodefaultlibs -lgcc -lc -lusb-1.0 -lpthread -luClibc++" \
+		LIBS="-nodefaultlibs -lgcc_s -lc -lusb-1.0 -lpthread -luClibc++" \
 		LDFLAGS="$(EXTRA_LDFLAGS)" \
 		CXXFLAGS="$(TARGET_CFLAGS) $(EXTRA_CPPFLAGS)" \
 		$(TARGET_CONFIGURE_OPTS) \


### PR DESCRIPTION
Fixed linker issue when compiling Lede v17.01.5+ using Ubuntu 18.04.1 LTS.
Using the switch -lgcc caused the build to fail, while changing it to -lgcc_s fixed the issue.